### PR TITLE
feat: add deploymentStrategy in values to populate deployment strategy

### DIFF
--- a/stable/s3-proxy/Chart.yaml
+++ b/stable/s3-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "3.3.0"
 description: A Helm chart for Kubernetes to deploy S3-Proxy
 name: s3-proxy
-version: 2.2.1
+version: 2.3.0
 home: https://github.com/oxyno-zeta/s3-proxy
 icon: https://raw.githubusercontent.com/oxyno-zeta/s3-proxy/master/docs/logo/logo.png
 sources:

--- a/stable/s3-proxy/templates/deployment.yaml
+++ b/stable/s3-proxy/templates/deployment.yaml
@@ -13,6 +13,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "s3-proxy.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- with .Values.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/stable/s3-proxy/values.yaml
+++ b/stable/s3-proxy/values.yaml
@@ -369,3 +369,9 @@ podDisruptionBudget:
   enabled: false
   minAvailable: 1
   maxUnavailable:
+
+deploymentStrategy: {}
+  # type: RollingUpdate
+  # rollingUpdate:
+  #   maxSurge: 1
+  #   maxUnavailable: 0


### PR DESCRIPTION
In order to support HA rolling deployments the ability to configure the deployment strategy is required.

This was implemented as backwards compatible by having a empty deploymentStrategy, however I suggest you adopt the commented out fields as the default since it allows deploying without downtime.